### PR TITLE
Take into account offset screen arrangements

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ var Positioner = (function () {
       // Default to right if the window is bigger than the space left.
       // Because on Windows the window might get out of bounds and dissappear.
       if (position.substr(0, 4) === 'tray') {
-        if (positions[position].x + windowSize[0] > screenSize.width) {
+        if (positions[position].x + windowSize[0] > screenSize.width + screenSize.x) {
           return {
             x: positions['topRight'].x,
             y: positions[position].y

--- a/src/Positioner.js
+++ b/src/Positioner.js
@@ -71,7 +71,7 @@ export default class Positioner {
     // Default to right if the window is bigger than the space left.
     // Because on Windows the window might get out of bounds and dissappear.
     if (position.substr(0, 4) === 'tray') {
-      if ((positions[position].x + windowSize[0]) > screenSize.width) {
+      if ((positions[position].x + windowSize[0]) > (screenSize.width + screenSize.x)) {
         return {
           x: positions['topRight'].x,
           y: positions[position].y


### PR DESCRIPTION
The fix to default to right doesn't include the screenSize's offset x position. This fixes that.

You can reproduce with monitors in this arrangement:
![screen shot 2015-12-10 at 4 31 48 pm](https://cloud.githubusercontent.com/assets/594035/11733036/c4e8d3f8-9f5e-11e5-8c87-d1443616c915.png)

This was the error:
![2015-12-01 at 5 34 pm](https://cloud.githubusercontent.com/assets/594035/11733041/ccfb87a2-9f5e-11e5-8adf-181710d2f187.png)

This is the fixed version:
<img width="99" alt="screen shot 2015-12-10 at 4 35 23 pm" src="https://cloud.githubusercontent.com/assets/594035/11733044/d4375bea-9f5e-11e5-9139-87fabbc89ac3.png">

Thanks!
