### PR TITLE
Support electron 1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var Positioner = (function () {
     _classCallCheck(this, Positioner);
 
     this.browserWindow = browserWindow;
-    this.electronScreen = require('screen');
+    this.electronScreen = require('electron').screen;
   }
 
   _createClass(Positioner, [{

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "standard"
+    "test": "standard",
+    "watch": "grunt watch"
   },
   "repository": {
     "type": "git",

--- a/src/Positioner.js
+++ b/src/Positioner.js
@@ -3,7 +3,7 @@
 export default class Positioner {
   constructor (browserWindow) {
     this.browserWindow = browserWindow
-    this.electronScreen = require('screen')
+    this.electronScreen = require('electron').screen
   }
 
   _getCoords (position, trayPosition) {


### PR DESCRIPTION
`screen` module should be loaded by either directly referencing `.screen` or through destructuring the electron object.
