### PR TITLE
Remove add-module-exports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["es2015"],
-  "plugins": ["add-module-exports"]
+  "presets": ["es2015"]
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "homepage": "https://github.com/jenslind/electron-positioner",
   "devDependencies": {
     "babel-cli": "^6.8.0",
-    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.6.0",
     "standard": "^5.1.0"
   },


### PR DESCRIPTION
The plugin `add-module-exports` breaks the default module export.

Babel is pretty permissive, and works fine with `import Positioner from 'electron-positioner'`, but TypeScript isn't, and forces me to do `import * as Positioner from 'electron-positioner'`.

I also believe the whole `add-module-exports` is unnecessary. Babel takes care of exporting and importing the right things already, no?