### PR TITLE
Get the screenWorkArea from the provided rect rather than the cursor

### DIFF
--- a/src/Positioner.js
+++ b/src/Positioner.js
@@ -87,11 +87,11 @@ export default class Positioner {
   }
 
   _getScreenSize (trayPosition) {
-  	if (trayPosition) {
-  		return this.electronScreen.getDisplayMatching(trayPosition).workArea
-  	} else {
-  		return this.electronScreen.getDisplayNearestPoint(this.electronScreen.getCursorScreenPoint()).workArea
-  	}
+    if (trayPosition) {
+      return this.electronScreen.getDisplayMatching(trayPosition).workArea
+    } else {
+      return this.electronScreen.getDisplayNearestPoint(this.electronScreen.getCursorScreenPoint()).workArea
+    }
   }
 
   move (position, trayPos) {

--- a/src/Positioner.js
+++ b/src/Positioner.js
@@ -7,7 +7,7 @@ export default class Positioner {
   }
 
   _getCoords (position, trayPosition) {
-    let screenSize = this._getScreenSize()
+    let screenSize = this._getScreenSize(trayPosition)
     let windowSize = this._getWindowSize()
 
     if (trayPosition === undefined) trayPosition = {}
@@ -86,8 +86,12 @@ export default class Positioner {
     return this.browserWindow.getSize()
   }
 
-  _getScreenSize () {
-    return this.electronScreen.getDisplayNearestPoint(this.electronScreen.getCursorScreenPoint()).workArea
+  _getScreenSize (trayPosition) {
+  	if (trayPosition) {
+  		return this.electronScreen.getDisplayMatching(trayPosition).workArea
+  	} else {
+  		return this.electronScreen.getDisplayNearestPoint(this.electronScreen.getCursorScreenPoint()).workArea
+  	}
   }
 
   move (position, trayPos) {


### PR DESCRIPTION
If you get the tray position via `tray.getBounds()` rather than through the click event, when the users cursor is on a different screen to the tray icon, the window will appear positioned incorrectly. The behaviour is most noticable when the screens have different resolutions

Setup your screens as so (`T` for tray, `C` for cursor)...
```
======================
|                    |    =============
|                    |    |           |   
|                    |    |      C    |  
|               T    |    ============= 
======================
```

This PR changes the `_getScreenSize` to get the `workArea` from the provided tray rect when available and if not from the mouse cursor (as it is now)